### PR TITLE
Use Engine.Scene; FNA-compatible frame stepping

### DIFF
--- a/Game/WhatsModified.txt
+++ b/Game/WhatsModified.txt
@@ -64,7 +64,6 @@ protected override void Update(GameTime gameTime)
 }
 ---------------------------------------------------------------------------------
 Changed a few fields/methods to public vs private.
-Monocle.Engine.scene
 Celeste.Player.dashCooldownTimer
 Celeste.Player.WallJumpCheck(int dir)
 Monocle.MInput.UpdateVirtualInputs()


### PR DESCRIPTION
- Use `Engine.Scene` instead of `Engine.Instance.scene` (`Scene` just loads `scene` internally)
- Store and compare the previous `dpadUp` / `dpadDown` states instead of using a locking loop. The FNA gamepad event loop occurs on the main thread.

This PR unfortunately breaks the studio's TAS status memory mappings.