### PR TITLE
Easier Copy + Paste for Update(GameTime)

### DIFF
--- a/Game/WhatsModified.txt
+++ b/Game/WhatsModified.txt
@@ -62,7 +62,7 @@ protected override void Update(GameTime gameTime)
 		{
 			base.Update(gameTime);
 		}
-		else if (i >= 8 && this.scene != null && this.scene.Tracker.GetEntity<FinalBoss>() != null)
+		else if (i >= 8 && this.scene != null && this.scene.Tracker.GetEntity<Celeste.FinalBoss>() != null)
 		{
 			break;
 		}


### PR DESCRIPTION
Added `Celeste.FinalBoss` instead of `FinalBoss` to skip the manuall entering of `using Celeste;` on top of file