### PR TITLE
Fix: Having multiple breakpoints would only break on the last one

### DIFF
--- a/Game/Celeste-Addons.csproj
+++ b/Game/Celeste-Addons.csproj
@@ -55,4 +55,12 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>REM automated deployment stuff, because I was too lazy to always
+REM copy the output file directly for every change (and didn't want
+REM to use a symlink for reasons)
+IF EXIST "$(ProjectDir)deploy.bat" (
+    call "$(ProjectDir)deploy.bat"
+)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/Game/InputController.cs
+++ b/Game/InputController.cs
@@ -153,6 +153,13 @@ namespace TAS {
 			if (Input.MenuUp.Check || Input.MoveY.Value < 0) { record.Actions |= Actions.Up; }
 			if (Input.MenuDown.Check || Input.MoveY.Value > 0) { record.Actions |= Actions.Down; }
 		}
+		internal void RemoveBreakpoint() {
+			if (Current.FastForward)
+			{
+				Current.FastForward = false;
+				fastForwards.RemoveAt(0);
+			}
+		}
 		public void WriteInputs() {
 			using (FileStream fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite)) {
 				for (int i = 0; i < inputs.Count; i++) {

--- a/Game/InputController.cs
+++ b/Game/InputController.cs
@@ -153,13 +153,6 @@ namespace TAS {
 			if (Input.MenuUp.Check || Input.MoveY.Value < 0) { record.Actions |= Actions.Up; }
 			if (Input.MenuDown.Check || Input.MoveY.Value > 0) { record.Actions |= Actions.Down; }
 		}
-		internal void RemoveBreakpoint() {
-			if (Current.FastForward)
-			{
-				Current.FastForward = false;
-				fastForwards.RemoveAt(0);
-			}
-		}
 		public void WriteInputs() {
 			using (FileStream fs = new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite)) {
 				for (int i = 0; i < inputs.Count; i++) {
@@ -192,6 +185,7 @@ namespace TAS {
 							fastForwards.Add(input);
 
 							if (inputs.Count > 0) {
+								inputs[inputs.Count - 1].ForceBreak = input.ForceBreak;
 								inputs[inputs.Count - 1].FastForward = true;
 							}
 						} else if (input.Frames != 0) {
@@ -239,6 +233,7 @@ namespace TAS {
 						fastForwards.Add(input);
 
 						if (inputs.Count > 0) {
+							inputs[inputs.Count - 1].ForceBreak = input.ForceBreak;
 							inputs[inputs.Count - 1].FastForward = true;
 						}
 					} else if (input.Frames != 0) {

--- a/Game/InputRecord.cs
+++ b/Game/InputRecord.cs
@@ -24,6 +24,7 @@ namespace TAS {
 		public Actions Actions { get; set; }
 		public float Angle { get; set; }
 		public bool FastForward { get; set; }
+		public bool ForceBreak { get; set; }
 		public InputRecord() { }
 		public InputRecord(int number, string line) {
 			Line = number;
@@ -31,9 +32,17 @@ namespace TAS {
 			int index = 0;
 			Frames = ReadFrames(line, ref index);
 			if (Frames == 0) {
+
+				// allow whitespace before the breakpoint
+				line = line.Trim();
 				if (line.StartsWith("***")) {
 					FastForward = true;
 					index = 3;
+
+					if(line.Length>=4 && line[3] == '!') {
+						ForceBreak = true;
+					}
+
 					Frames = ReadFrames(line, ref index);
 				}
 				return;

--- a/Game/Manager.cs
+++ b/Game/Manager.cs
@@ -108,7 +108,8 @@ namespace TAS {
 				} else {
 					bool fastForward = controller.HasFastForward;
 					controller.PlaybackPlayer();
-					if (fastForward && !controller.HasFastForward) {
+					if (fastForward && controller.Current.FastForward) {
+						controller.RemoveBreakpoint();
 						nextState |= State.FrameStep;
 						FrameLoops = 1;
 					}

--- a/Game/Manager.cs
+++ b/Game/Manager.cs
@@ -108,8 +108,9 @@ namespace TAS {
 				} else {
 					bool fastForward = controller.HasFastForward;
 					controller.PlaybackPlayer();
-					if (fastForward && controller.Current.FastForward && controller.CurrentInputFrame == controller.Current.Frames) {
-						controller.RemoveBreakpoint();
+					if (fastForward
+						&& (!controller.HasFastForward
+							|| controller.Current.ForceBreak && controller.CurrentInputFrame == controller.Current.Frames)) {
 						nextState |= State.FrameStep;
 						FrameLoops = 1;
 					}

--- a/Game/Manager.cs
+++ b/Game/Manager.cs
@@ -108,7 +108,7 @@ namespace TAS {
 				} else {
 					bool fastForward = controller.HasFastForward;
 					controller.PlaybackPlayer();
-					if (fastForward && controller.Current.FastForward) {
+					if (fastForward && controller.Current.FastForward && controller.CurrentInputFrame == controller.Current.Frames) {
 						controller.RemoveBreakpoint();
 						nextState |= State.FrameStep;
 						FrameLoops = 1;


### PR DESCRIPTION
This is because the break (aka "go to frame step mode") condition would only actually break if no later breakpoints were available.

As an aside:
While the project file change doesn't technically belong to the change, it doesn't do anything if you don't have a "deploy.bat" file lying around in the project directory, so I decided to keep it in. Maybe someone finds it useful in the future.